### PR TITLE
changed 'env' to 'environment' in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the official website of Programming club, UIET, Panjab University
     ```
     We recommend using python-virtualenv. Any other packages would do fine though.
 
-3. Activate the newly created virtual env:
+3. Activate the newly created virtual environment:
     ```
     cd env
     source bin/activate

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the official website of Programming club, UIET, Panjab University
     ```
     We recommend using python-virtualenv. Any other packages would do fine though.
 
-3. Activate the newly created virtual environment:
+3. Activate the newly created virtual env:
     ```
     cd env
     source bin/activate


### PR DESCRIPTION
Corrected 'env' to environment on line no. 13 

In the README.md file the word 'env' on line no.13 was changed to 'environment' to avoid the confusions.

Resolves: #37 