### PR TITLE
Configure project for deployment to heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn pclubWebsite.wsgi

--- a/pclubWebsite/settings.py
+++ b/pclubWebsite/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -25,7 +26,7 @@ SECRET_KEY = '$4p#tsin((&rnm!%696^2xutz_-n5k)o&mnwg3z*^f7&--99h&'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -36,7 +37,9 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
+
     'home',
 ]
 
@@ -48,6 +51,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
 ROOT_URLCONF = 'pclubWebsite.urls'
@@ -73,7 +77,6 @@ WSGI_APPLICATION = 'pclubWebsite.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -114,7 +117,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-
+DATABASES['default'].update(dj_database_url.config(conn_max_age=500))
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
@@ -124,3 +127,6 @@ STATICFILES_DIRS = [ os.path.join(BASE_DIR,'home','staticFiles') ]
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+dj-database-url==0.4.2
 Django==1.11.5
+gunicorn==19.7.1
+psycopg2==2.7.3.1
 pytz==2017.2
+whitenoise==3.3.1


### PR DESCRIPTION
settings.py has necessary settings to deploy to heroku.
requirements.txt was updated too and whitenoise is used
for management of staticfiles as it makes it easy to
serve staticfiles in an app heroku and is the preferred
standard.