### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+# command to run tests
+script: python manage.py test


### PR DESCRIPTION
This file is needed to integrate Travis CI
to a project. It specifies the language to be
used i.e. python and similar settings for testing.