### PR TITLE
"/" redirects to "/home"

### DIFF
--- a/pclubWebsite/urls.py
+++ b/pclubWebsite/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
 """
 from django.conf.urls import url, include
 from django.contrib import admin
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^home/', include('home.urls')),
+    url(r'^$', RedirectView.as_view(url='/home/')),
 ]


### PR DESCRIPTION
Fixes issue #66

Changes: Used RedirectView to make "/" redirect to "/home"

Run `python3 manage.py runserver`
Open http://127.0.0.1:8000 in a web browser, it should redirect to http://127.0.0.1:8000/home